### PR TITLE
Previously registered protocols were unregistered.

### DIFF
--- a/Source/JiveAuthenticatingHTTPProtocol/JAHPAuthenticatingHTTPProtocol.m
+++ b/Source/JiveAuthenticatingHTTPProtocol/JAHPAuthenticatingHTTPProtocol.m
@@ -159,7 +159,11 @@ static NSString * sUserAgentToken;
         config = [NSURLSessionConfiguration defaultSessionConfiguration];
         // You have to explicitly configure the session to use your own protocol subclass here
         // otherwise you don't see redirects <rdar://problem/17384498>.
-        config.protocolClasses = @[ self ];
+        if (config.protocolClasses) {
+            config.protocolClasses = [config.protocolClasses arrayByAddingObject:self];
+        } else {
+            config.protocolClasses = @[ self ];
+        }
         sDemux = [[JAHPQNSURLSessionDemux alloc] initWithConfiguration:config];
     });
     return sDemux;


### PR DESCRIPTION
If another NSURLProtocol was registered on the NSURLSession's
defaultConfiguration, it would be unregistered when
JAHPAuthenticatingHTTPProtocol was registered and used.
