### PR TITLE
Refactoring and creds memoization with the original code formatting

### DIFF
--- a/JiveAuthenticatingHTTPProtocolDemo/JiveAuthenticatingHTTPProtocolDemo/ViewController.m
+++ b/JiveAuthenticatingHTTPProtocolDemo/JiveAuthenticatingHTTPProtocolDemo/ViewController.m
@@ -36,7 +36,19 @@
 #pragma mark - JAHPAuthenticatingHTTPProtocolDelegate
 
 - (BOOL)authenticatingHTTPProtocol:(JAHPAuthenticatingHTTPProtocol *)authenticatingHTTPProtocol canAuthenticateAgainstProtectionSpace:(NSURLProtectionSpace *)protectionSpace {
-    BOOL canAuthenticate = [protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodHTTPBasic];
+
+    NSArray* interceptedAuthMethods =
+    @[
+        NSURLAuthenticationMethodHTTPBasic
+      , NSURLAuthenticationMethodHTTPDigest
+      , NSURLAuthenticationMethodNTLM
+    ];
+    
+    NSSet* interceptedAuthMethodsSet = [NSSet setWithArray: interceptedAuthMethods];
+    
+    BOOL canAuthenticate =
+    [interceptedAuthMethodsSet containsObject: protectionSpace.authenticationMethod];
+    
     return canAuthenticate;
 }
 

--- a/JiveAuthenticatingHTTPProtocolDemo/JiveAuthenticatingHTTPProtocolDemo/ViewController.m
+++ b/JiveAuthenticatingHTTPProtocolDemo/JiveAuthenticatingHTTPProtocolDemo/ViewController.m
@@ -30,7 +30,7 @@
     [JAHPAuthenticatingHTTPProtocol setDelegate:self];
     [JAHPAuthenticatingHTTPProtocol start];
     self.webView.delegate = self;
-    [self.webView loadRequest:[[NSURLRequest alloc] initWithURL:[NSURL URLWithString:@"http://httpbin.org/basic-auth/foo/bar"]]];
+    [self.webView loadRequest:[[NSURLRequest alloc] initWithURL:[NSURL URLWithString:@"https://httpbin.org/basic-auth/foo/bar"]]];
 }
 
 #pragma mark - JAHPAuthenticatingHTTPProtocolDelegate
@@ -127,7 +127,7 @@
 // Then all logs will go to the `authenticatingHTTPProtocol:logMessage:` method
 //
 //- (void)authenticatingHTTPProtocol:(JAHPAuthenticatingHTTPProtocol *)authenticatingHTTPProtocol logWithFormat:(NSString *)format arguments:(va_list)arguments {
-//    
+//
 //    NSLog(@"logWithFormat: %@", [[NSString alloc] initWithFormat:format arguments:arguments]);
 //}
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,66 @@ JiveAuthenticatingHTTPProtocol
 Based on [Apple's CustomHTTPProtocol](https://developer.apple.com/library/prerelease/ios/samplecode/CustomHTTPProtocol/Introduction/Intro.html),
 `JiveAuthenticatingHTTPProtocol` provides authentication callbacks for a `UIWebView`.
 
+#### Note :
+
+```
+No cleanup of the sample code has been done, so there might be some strange "patterns" inside. 
+```
+
+See https://github.com/jivesoftware/JiveAuthenticatingHTTPProtocol/issues/3 for more details.
+
+
 Usage
 -----
-`JiveAuthenticatingHTTPProtocol` captures all `NSURLConnection` traffic. Ensure that no other `NSURLConnection`s can start after you call `+[JAHPAuthenticatingHTTPProtocol start]`. Before loading an `NSURLRequest` that may require handling an authentication callback, call `+[JAHPAuthenticatingHTTPProtocol setDelegate:]`, then `+[JAHPAuthenticatingHTTPProtocol start]`. Finally, load your `NSURLRequest`, and handle the callbacks from `JAHPAuthenticatingHTTPProtocolDelegate`.
+`JiveAuthenticatingHTTPProtocol` captures all `NSURLConnection` traffic. 
 
-See JiveAuthenticatingHTTPProtocolDemo/ViewController.m for an example.
+1. Ensure that no other `NSURLConnection`s can start after you call `+[JAHPAuthenticatingHTTPProtocol start]`. 
+2. Before loading an `NSURLRequest` that may require handling an authentication callback, call `+[JAHPAuthenticatingHTTPProtocol setDelegate:]`, 
+3. Then call `+[JAHPAuthenticatingHTTPProtocol start]`. 
+4. Finally, load your `NSURLRequest`, and handle the callbacks from `JAHPAuthenticatingHTTPProtocolDelegate`.
+
+See `JiveAuthenticatingHTTPProtocolDemo/ViewController.m` for an example.
+
+It might be a good idea to memoize the credentials entered by the user to avoid "spamming" them with the data input alerts. This is an absolute "must" if your page contains the video which requires authorization.
+
+
+
+Supported Authorization Methods
+-----
+This library supports all of the authentication schemes `NSURLAuthentication` supports.
+
+This has been tested with `NTLM` and `ADFS` authentication, (which `NSURLAuthentication` natively supports). Basically, if an authentication method works in `Safari`, it'll probably work here, too.
+
+You can add more authorization methods like this :
+
+```obj-c
+- (BOOL)authenticatingHTTPProtocol:(JAHPAuthenticatingHTTPProtocol *)authenticatingHTTPProtocol
+canAuthenticateAgainstProtectionSpace:(NSURLProtectionSpace *)protectionSpace
+{
+    NSArray* interceptedAuthMethods =
+    @[
+      NSURLAuthenticationMethodHTTPBasic
+      , NSURLAuthenticationMethodNTLM
+    ];
+    
+    NSSet* interceptedAuthMethodsSet = [NSSet setWithArray: interceptedAuthMethods];
+    
+    BOOL canAuthenticate =
+        [interceptedAuthMethodsSet containsObject: protectionSpace.authenticationMethod];
+    
+    return canAuthenticate;
+}
+```
+
+
+#### Caution : 
+
+```
+Stubbing the above function to always return "true" is not always a good idea.
+If you do so, it would be your responsibility to implement all the required handshakes.
+```
+
+
 
 License
 -------

--- a/Source/JiveAuthenticatingHTTPProtocol/JAHPAuthenticatingHTTPProtocol.m
+++ b/Source/JiveAuthenticatingHTTPProtocol/JAHPAuthenticatingHTTPProtocol.m
@@ -253,9 +253,9 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
     // NSURLProtocol subclass.
     
     if (shouldAccept) {
-        shouldAccept = YES && [scheme isEqual:@"http"];
+        shouldAccept = [scheme isEqual:@"http"];
         if ( ! shouldAccept ) {
-            shouldAccept = YES && [scheme isEqual:@"https"];
+            shouldAccept = [scheme isEqual:@"https"];
         }
         
         if ( ! shouldAccept ) {

--- a/Source/JiveAuthenticatingHTTPProtocol/JAHPAuthenticatingHTTPProtocol.m
+++ b/Source/JiveAuthenticatingHTTPProtocol/JAHPAuthenticatingHTTPProtocol.m
@@ -272,7 +272,7 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
 {
     NSURLRequest *      result;
     
-    assert(request != nil);
+    NSParameterAssert(request != nil);
     // can be called on any thread
     
     // Canonicalising a request is quite complex, so all the heavy lifting has
@@ -287,9 +287,9 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
 
 - (id)initWithRequest:(NSURLRequest *)request cachedResponse:(NSCachedURLResponse *)cachedResponse client:(id <NSURLProtocolClient>)client
 {
-    assert(request != nil);
+    NSParameterAssert(request != nil);
     // cachedResponse may be nil
-    assert(client != nil);
+    NSParameterAssert(client != nil);
     // can be called on any thread
     
     NSMutableURLRequest *mutableRequest = [request mutableCopy];
@@ -327,9 +327,9 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
 {
     // can be called on any thread
     [[self class] authenticatingHTTPProtocol:self logWithFormat:@"dealloc"];
-    assert(self->_task == nil);                     // we should have cleared it by now
-    assert(self->_pendingChallenge == nil);         // we should have cancelled it by now
-    assert(self->_pendingChallengeCompletionHandler == nil);    // we should have cancelled it by now
+    NSParameterAssert(self->_task == nil);                     // we should have cleared it by now
+    NSParameterAssert(self->_pendingChallenge == nil);         // we should have cancelled it by now
+    NSParameterAssert(self->_pendingChallengeCompletionHandler == nil);    // we should have cancelled it by now
 }
 
 - (void)startLoading
@@ -341,8 +341,8 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
     // At this point we kick off the process of loading the URL via NSURLSession.
     // The thread that calls this method becomes the client thread.
     
-    assert(self.clientThread == nil);           // you can't call -startLoading twice
-    assert(self.task == nil);
+    NSParameterAssert(self.clientThread == nil);           // you can't call -startLoading twice
+    NSParameterAssert(self.task == nil);
     
     // Calculate our effective run loop modes.  In some circumstances (yes I'm looking at
     // you UIWebView!) we can be called from a non-standard thread which then runs a
@@ -353,7 +353,7 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
     // For debugging purposes the non-standard mode is "WebCoreSynchronousLoaderRunLoopMode"
     // but it's better not to hard-code that here.
     
-    assert(self.modes == nil);
+    NSParameterAssert(self.modes == nil);
     calculatedModes = [NSMutableArray array];
     [calculatedModes addObject:NSDefaultRunLoopMode];
     currentMode = [[NSRunLoop currentRunLoop] currentMode];
@@ -361,13 +361,13 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
         [calculatedModes addObject:currentMode];
     }
     self.modes = calculatedModes;
-    assert([self.modes count] > 0);
+    NSParameterAssert([self.modes count] > 0);
     
     // Create new request that's a clone of the request we were initialised with,
     // except that it has our 'recursive request flag' property set on it.
     
     recursiveRequest = [[self request] mutableCopy];
-    assert(recursiveRequest != nil);
+    NSParameterAssert(recursiveRequest != nil);
     
     [[self class] setProperty:@YES forKey:kJAHPRecursiveRequestFlagProperty inRequest:recursiveRequest];
     
@@ -385,7 +385,7 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
     // Once everything is ready to go, create a data task with the new request.
     
     self.task = [[[self class] sharedDemux] dataTaskWithRequest:recursiveRequest delegate:self modes:self.modes];
-    assert(self.task != nil);
+    NSParameterAssert(self.task != nil);
     
     [self.task resume];
 }
@@ -396,7 +396,7 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
     
     [[self class] authenticatingHTTPProtocol:self logWithFormat:@"stop (elapsed %.1f)", [NSDate timeIntervalSinceReferenceDate] - self.startTime];
     
-    assert(self.clientThread != nil);           // someone must have called -startLoading
+    NSParameterAssert(self.clientThread != nil);           // someone must have called -startLoading
     
     // Check that we're being stopped on the same thread that we were started
     // on.  Without this invariant things are going to go badly (for example,
@@ -408,7 +408,7 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
     // Rather, I rely on our client calling us on the right thread, which is what
     // the following assert is about.
     
-    assert([NSThread currentThread] == self.clientThread);
+    NSParameterAssert([NSThread currentThread] == self.clientThread);
     
     [self cancelPendingChallenge];
     if (self.task != nil) {
@@ -432,7 +432,7 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
 {
     // thread may be nil
     // modes may be nil
-    assert(block != nil);
+    NSParameterAssert(block != nil);
     
     if (thread == nil) {
         thread = [NSThread mainThread];
@@ -450,7 +450,7 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
 
 - (void)onThreadPerformBlock:(dispatch_block_t)block
 {
-    assert(block != nil);
+    NSParameterAssert(block != nil);
     block();
 }
 
@@ -475,9 +475,9 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
 
 - (void)didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(JAHPChallengeCompletionHandler)completionHandler
 {
-    assert(challenge != nil);
-    assert(completionHandler != nil);
-    assert([NSThread currentThread] == self.clientThread);
+    NSParameterAssert(challenge != nil);
+    NSParameterAssert(completionHandler != nil);
+    NSParameterAssert([NSThread currentThread] == self.clientThread);
     
     [[self class] authenticatingHTTPProtocol:self logWithFormat:@"challenge %@ received", [[challenge protectionSpace] authenticationMethod]];
     
@@ -498,9 +498,9 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
 
 - (void)mainThreadDidReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(JAHPChallengeCompletionHandler)completionHandler
 {
-    assert(challenge != nil);
-    assert(completionHandler != nil);
-    assert([NSThread isMainThread]);
+    NSParameterAssert(challenge != nil);
+    NSParameterAssert(completionHandler != nil);
+    NSParameterAssert([NSThread isMainThread]);
     
     if (self.pendingChallenge != nil) {
         
@@ -512,7 +512,7 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
         // namely, the client thread.
         
         [[self class] authenticatingHTTPProtocol:self logWithFormat:@"challenge %@ cancelled; other challenge pending", [[challenge protectionSpace] authenticationMethod]];
-        assert(NO);
+        NSParameterAssert(NO);
         [self clientThreadCancelAuthenticationChallenge:challenge completionHandler:completionHandler];
     } else {
         id<JAHPAuthenticatingHTTPProtocolDelegate>  strongDelegate;
@@ -526,7 +526,7 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
         
         if ( ! [strongDelegate respondsToSelector:@selector(authenticatingHTTPProtocol:canAuthenticateAgainstProtectionSpace:)] ) {
             [[self class] authenticatingHTTPProtocol:self logWithFormat:@"challenge %@ cancelled; no delegate method", [[challenge protectionSpace] authenticationMethod]];
-            assert(NO);
+            NSParameterAssert(NO);
             [self clientThreadCancelAuthenticationChallenge:challenge completionHandler:completionHandler];
         } else {
             
@@ -556,9 +556,9 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
 - (void)clientThreadCancelAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(JAHPChallengeCompletionHandler)completionHandler
 {
 #pragma unused(challenge)
-    assert(challenge != nil);
-    assert(completionHandler != nil);
-    assert([NSThread isMainThread]);
+    NSParameterAssert(challenge != nil);
+    NSParameterAssert(completionHandler != nil);
+    NSParameterAssert([NSThread isMainThread]);
     
     [self performOnThread:self.clientThread modes:self.modes block:^{
         completionHandler(NSURLSessionAuthChallengeCancelAuthenticationChallenge, nil);
@@ -574,7 +574,7 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
 
 - (void)cancelPendingChallenge
 {
-    assert([NSThread currentThread] == self.clientThread);
+    NSParameterAssert([NSThread currentThread] == self.clientThread);
     
     // Just pass the work off to the main thread.  We do this so that all accesses
     // to pendingChallenge are done from the main thread, which avoids the need for
@@ -613,7 +613,7 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
                 [[self class] authenticatingHTTPProtocol:self logWithFormat:@"challenge %@ cancellation failed; no delegate method", [[challenge protectionSpace] authenticationMethod]];
                 // If we managed to send a challenge to the client but can't cancel it, that's bad.
                 // There's nothing we can do at this point except log the problem.
-                assert(NO);
+                NSParameterAssert(NO);
             }
         }
     }];
@@ -622,8 +622,8 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
 - (void)resolvePendingAuthenticationChallengeWithCredential:(NSURLCredential *)credential
 {
     // credential may be nil
-    assert([NSThread isMainThread]);
-    assert(self.clientThread != nil);
+    NSParameterAssert([NSThread isMainThread]);
+    NSParameterAssert(self.clientThread != nil);
     
     JAHPChallengeCompletionHandler  completionHandler;
     NSURLAuthenticationChallenge *challenge;
@@ -650,8 +650,8 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
 }
 
 - (void)cancelPendingAuthenticationChallenge {
-    assert([NSThread isMainThread]);
-    assert(self.clientThread != nil);
+    NSParameterAssert([NSThread isMainThread]);
+    NSParameterAssert(self.clientThread != nil);
     
     JAHPChallengeCompletionHandler  completionHandler;
     NSURLAuthenticationChallenge *challenge;
@@ -690,12 +690,12 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
     
 #pragma unused(session)
 #pragma unused(task)
-    assert(task == self.task);
-    assert(response != nil);
-    assert(newRequest != nil);
+    NSParameterAssert(task == self.task);
+    NSParameterAssert(response != nil);
+    NSParameterAssert(newRequest != nil);
 #pragma unused(completionHandler)
-    assert(completionHandler != nil);
-    assert([NSThread currentThread] == self.clientThread);
+    NSParameterAssert(completionHandler != nil);
+    NSParameterAssert([NSThread currentThread] == self.clientThread);
     
     [[self class] authenticatingHTTPProtocol:self logWithFormat:@"will redirect from %@ to %@", [response URL], [newRequest URL]];
     
@@ -707,7 +707,7 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
     // We also cancel our current connection because the client is going to start a new request for
     // us anyway.
     
-    assert([[self class] propertyForKey:kJAHPRecursiveRequestFlagProperty inRequest:newRequest] != nil);
+    NSParameterAssert([[self class] propertyForKey:kJAHPRecursiveRequestFlagProperty inRequest:newRequest] != nil);
     
     redirectRequest = [newRequest mutableCopy];
     [[self class] removePropertyForKey:kJAHPRecursiveRequestFlagProperty inRequest:redirectRequest];
@@ -742,10 +742,10 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
     
 #pragma unused(session)
 #pragma unused(task)
-    assert(task == self.task);
-    assert(challenge != nil);
-    assert(completionHandler != nil);
-    assert([NSThread currentThread] == self.clientThread);
+    NSParameterAssert(task == self.task);
+    NSParameterAssert(challenge != nil);
+    NSParameterAssert(completionHandler != nil);
+    NSParameterAssert([NSThread currentThread] == self.clientThread);
     
     // Ask our delegate whether it wants this challenge.  We do this from this thread, not the main thread,
     // to avoid the overload of bouncing to the main thread for challenges that aren't going to be customised
@@ -786,10 +786,10 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
     
 #pragma unused(session)
 #pragma unused(dataTask)
-    assert(dataTask == self.task);
-    assert(response != nil);
-    assert(completionHandler != nil);
-    assert([NSThread currentThread] == self.clientThread);
+    NSParameterAssert(dataTask == self.task);
+    NSParameterAssert(response != nil);
+    NSParameterAssert(completionHandler != nil);
+    NSParameterAssert([NSThread currentThread] == self.clientThread);
     
     // Pass the call on to our client.  The only tricky thing is that we have to decide on a
     // cache storage policy, which is based on the actual request we issued, not the request
@@ -799,7 +799,7 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
         cacheStoragePolicy = JAHPCacheStoragePolicyForRequestAndResponse(self.task.originalRequest, (NSHTTPURLResponse *) response);
         statusCode = [((NSHTTPURLResponse *) response) statusCode];
     } else {
-        assert(NO);
+        NSParameterAssert(NO);
         cacheStoragePolicy = NSURLCacheStorageNotAllowed;
         statusCode = 42;
     }
@@ -823,9 +823,9 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
     
 #pragma unused(session)
 #pragma unused(dataTask)
-    assert(dataTask == self.task);
-    assert(data != nil);
-    assert([NSThread currentThread] == self.clientThread);
+    NSParameterAssert(dataTask == self.task);
+    NSParameterAssert(data != nil);
+    NSParameterAssert([NSThread currentThread] == self.clientThread);
     
     // Just pass the call on to our client.
     
@@ -846,10 +846,10 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
     
 #pragma unused(session)
 #pragma unused(dataTask)
-    assert(dataTask == self.task);
-    assert(proposedResponse != nil);
-    assert(completionHandler != nil);
-    assert([NSThread currentThread] == self.clientThread);
+    NSParameterAssert(dataTask == self.task);
+    NSParameterAssert(proposedResponse != nil);
+    NSParameterAssert(completionHandler != nil);
+    NSParameterAssert([NSThread currentThread] == self.clientThread);
     
     // We implement this delegate callback purely for the purposes of logging.
     
@@ -863,8 +863,8 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
 {
 #pragma unused(session)
 #pragma unused(task)
-    assert( (self.task == nil) || (task == self.task) );        // can be nil in the 'cancel from -stopLoading' case
-    assert([NSThread currentThread] == self.clientThread);
+    NSParameterAssert( (self.task == nil) || (task == self.task) );        // can be nil in the 'cancel from -stopLoading' case
+    NSParameterAssert([NSThread currentThread] == self.clientThread);
     
     // Just log and then, in most cases, pass the call on to our client.
     

--- a/Source/JiveAuthenticatingHTTPProtocol/JAHPCacheStoragePolicy.h
+++ b/Source/JiveAuthenticatingHTTPProtocol/JAHPCacheStoragePolicy.h
@@ -58,4 +58,4 @@
  *  \returns A cache storage policy to use.
  */
 
-extern NSURLCacheStoragePolicy JAHPCacheStoragePolicyForRequestAndResponse(NSURLRequest * request, NSHTTPURLResponse * response);
+FOUNDATION_EXPORT NSURLCacheStoragePolicy JAHPCacheStoragePolicyForRequestAndResponse(NSURLRequest * request, NSHTTPURLResponse * response);

--- a/Source/JiveAuthenticatingHTTPProtocol/JAHPCacheStoragePolicy.m
+++ b/Source/JiveAuthenticatingHTTPProtocol/JAHPCacheStoragePolicy.m
@@ -47,7 +47,7 @@
 
 #import "JAHPCacheStoragePolicy.h"
 
-extern NSURLCacheStoragePolicy JAHPCacheStoragePolicyForRequestAndResponse(NSURLRequest * request, NSHTTPURLResponse * response)
+FOUNDATION_EXPORT NSURLCacheStoragePolicy JAHPCacheStoragePolicyForRequestAndResponse(NSURLRequest * request, NSHTTPURLResponse * response)
 // See comment in header.
 {
     BOOL                        cacheable;

--- a/Source/JiveAuthenticatingHTTPProtocol/JAHPCanonicalRequest.h
+++ b/Source/JiveAuthenticatingHTTPProtocol/JAHPCanonicalRequest.h
@@ -61,4 +61,4 @@
  *  \returns The canonical request; should never be nil.
  */
 
-extern NSMutableURLRequest * JAHPCanonicalRequestForRequest(NSURLRequest *request);
+FOUNDATION_EXPORT NSMutableURLRequest * JAHPCanonicalRequestForRequest(NSURLRequest *request);

--- a/Source/JiveAuthenticatingHTTPProtocol/JAHPCanonicalRequest.m
+++ b/Source/JiveAuthenticatingHTTPProtocol/JAHPCanonicalRequest.m
@@ -343,7 +343,7 @@ static void CanonicaliseHeaders(NSMutableURLRequest * request)
 
 #pragma mark * API
 
-extern NSMutableURLRequest * JAHPCanonicalRequestForRequest(NSURLRequest *request)
+FOUNDATION_EXPORT NSMutableURLRequest * JAHPCanonicalRequestForRequest(NSURLRequest *request)
 {
     NSMutableURLRequest *   result;
     NSString *              scheme;

--- a/Source/JiveAuthenticatingHTTPProtocol/JAHPQNSURLSessionDemux.m
+++ b/Source/JiveAuthenticatingHTTPProtocol/JAHPQNSURLSessionDemux.m
@@ -73,9 +73,9 @@
 
 - (instancetype)initWithTask:(NSURLSessionDataTask *)task delegate:(id<NSURLSessionDataDelegate>)delegate modes:(NSArray *)modes
 {
-    assert(task != nil);
-    assert(delegate != nil);
-    assert(modes != nil);
+    NSParameterAssert(task != nil);
+    NSParameterAssert(delegate != nil);
+    NSParameterAssert(modes != nil);
     
     self = [super init];
     if (self != nil) {
@@ -89,14 +89,14 @@
 
 - (void)performBlock:(dispatch_block_t)block
 {
-    assert(self.delegate != nil);
-    assert(self.thread != nil);
+    NSParameterAssert(self.delegate != nil);
+    NSParameterAssert(self.thread != nil);
     [self performSelector:@selector(performBlockOnClientThread:) onThread:self.thread withObject:[block copy] waitUntilDone:NO modes:self.modes];
 }
 
 - (void)performBlockOnClientThread:(dispatch_block_t)block
 {
-    assert([NSThread currentThread] == self.thread);
+    NSParameterAssert([NSThread currentThread] == self.thread);
     block();
 }
 
@@ -149,8 +149,8 @@
     NSURLSessionDataTask *          task;
     JAHPQNSURLSessionDemuxTaskInfo *    taskInfo;
     
-    assert(request != nil);
-    assert(delegate != nil);
+    NSParameterAssert(request != nil);
+    NSParameterAssert(delegate != nil);
     // modes may be nil
     
     if ([modes count] == 0) {
@@ -158,7 +158,7 @@
     }
     
     task = [self.session dataTaskWithRequest:request];
-    assert(task != nil);
+    NSParameterAssert(task != nil);
     
     taskInfo = [[JAHPQNSURLSessionDemuxTaskInfo alloc] initWithTask:task delegate:delegate modes:modes];
     
@@ -173,11 +173,11 @@
 {
     JAHPQNSURLSessionDemuxTaskInfo *    result;
     
-    assert(task != nil);
+    NSParameterAssert(task != nil);
     
     @synchronized (self) {
         result = self.taskInfoByTaskID[@(task.taskIdentifier)];
-        assert(result != nil);
+        NSParameterAssert(result != nil);
     }
     return result;
 }
@@ -187,7 +187,7 @@
     JAHPQNSURLSessionDemuxTaskInfo *    taskInfo;
     
     taskInfo = [self taskInfoForTask:task];
-    if ([taskInfo.delegate respondsToSelector:@selector(URLSession:task:willPerformHTTPRedirection:newRequest:completionHandler:)]) {
+    if ([taskInfo.delegate respondsToSelector:_cmd]) {
         [taskInfo performBlock:^{
             [taskInfo.delegate URLSession:session task:task willPerformHTTPRedirection:response newRequest:newRequest completionHandler:completionHandler];
         }];
@@ -201,7 +201,7 @@
     JAHPQNSURLSessionDemuxTaskInfo *    taskInfo;
     
     taskInfo = [self taskInfoForTask:task];
-    if ([taskInfo.delegate respondsToSelector:@selector(URLSession:task:didReceiveChallenge:completionHandler:)]) {
+    if ([taskInfo.delegate respondsToSelector:_cmd]) {
         [taskInfo performBlock:^{
             [taskInfo.delegate URLSession:session task:task didReceiveChallenge:challenge completionHandler:completionHandler];
         }];
@@ -215,7 +215,7 @@
     JAHPQNSURLSessionDemuxTaskInfo *    taskInfo;
     
     taskInfo = [self taskInfoForTask:task];
-    if ([taskInfo.delegate respondsToSelector:@selector(URLSession:task:needNewBodyStream:)]) {
+    if ([taskInfo.delegate respondsToSelector:_cmd]) {
         [taskInfo performBlock:^{
             [taskInfo.delegate URLSession:session task:task needNewBodyStream:completionHandler];
         }];
@@ -229,7 +229,7 @@
     JAHPQNSURLSessionDemuxTaskInfo *    taskInfo;
     
     taskInfo = [self taskInfoForTask:task];
-    if ([taskInfo.delegate respondsToSelector:@selector(URLSession:task:didSendBodyData:totalBytesSent:totalBytesExpectedToSend:)]) {
+    if ([taskInfo.delegate respondsToSelector:_cmd]) {
         [taskInfo performBlock:^{
             [taskInfo.delegate URLSession:session task:task didSendBodyData:bytesSent totalBytesSent:totalBytesSent totalBytesExpectedToSend:totalBytesExpectedToSend];
         }];
@@ -252,7 +252,7 @@
     // after calling the delegate, otherwise the client thread side of the -performBlock: code can
     // find itself with an invalidated task info.
     
-    if ([taskInfo.delegate respondsToSelector:@selector(URLSession:task:didCompleteWithError:)]) {
+    if ([taskInfo.delegate respondsToSelector:_cmd]) {
         [taskInfo performBlock:^{
             [taskInfo.delegate URLSession:session task:task didCompleteWithError:error];
             [taskInfo invalidate];
@@ -267,7 +267,7 @@
     JAHPQNSURLSessionDemuxTaskInfo *    taskInfo;
     
     taskInfo = [self taskInfoForTask:dataTask];
-    if ([taskInfo.delegate respondsToSelector:@selector(URLSession:dataTask:didReceiveResponse:completionHandler:)]) {
+    if ([taskInfo.delegate respondsToSelector:_cmd]) {
         [taskInfo performBlock:^{
             [taskInfo.delegate URLSession:session dataTask:dataTask didReceiveResponse:response completionHandler:completionHandler];
         }];
@@ -281,7 +281,7 @@
     JAHPQNSURLSessionDemuxTaskInfo *    taskInfo;
     
     taskInfo = [self taskInfoForTask:dataTask];
-    if ([taskInfo.delegate respondsToSelector:@selector(URLSession:dataTask:didBecomeDownloadTask:)]) {
+    if ([taskInfo.delegate respondsToSelector:_cmd]) {
         [taskInfo performBlock:^{
             [taskInfo.delegate URLSession:session dataTask:dataTask didBecomeDownloadTask:downloadTask];
         }];
@@ -293,7 +293,7 @@
     JAHPQNSURLSessionDemuxTaskInfo *    taskInfo;
     
     taskInfo = [self taskInfoForTask:dataTask];
-    if ([taskInfo.delegate respondsToSelector:@selector(URLSession:dataTask:didReceiveData:)]) {
+    if ([taskInfo.delegate respondsToSelector:_cmd]) {
         [taskInfo performBlock:^{
             [taskInfo.delegate URLSession:session dataTask:dataTask didReceiveData:data];
         }];
@@ -305,7 +305,7 @@
     JAHPQNSURLSessionDemuxTaskInfo *    taskInfo;
     
     taskInfo = [self taskInfoForTask:dataTask];
-    if ([taskInfo.delegate respondsToSelector:@selector(URLSession:dataTask:willCacheResponse:completionHandler:)]) {
+    if ([taskInfo.delegate respondsToSelector:_cmd]) {
         [taskInfo performBlock:^{
             [taskInfo.delegate URLSession:session dataTask:dataTask willCacheResponse:proposedResponse completionHandler:completionHandler];
         }];


### PR DESCRIPTION
Same as https://github.com/jivesoftware/JiveAuthenticatingHTTPProtocol/pull/7 but keeping the original code formatting.

Addressing https://github.com/jivesoftware/JiveAuthenticatingHTTPProtocol/issues/3 and https://github.com/jivesoftware/JiveAuthenticatingHTTPProtocol/issues/6