### PR TITLE
[memoization] fix incorrect credentials asynchronous loop

### DIFF
--- a/JiveAuthenticatingHTTPProtocol.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/JiveAuthenticatingHTTPProtocol.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/JiveAuthenticatingHTTPProtocolDemo/JiveAuthenticatingHTTPProtocolDemo.xcodeproj/project.pbxproj
+++ b/JiveAuthenticatingHTTPProtocolDemo/JiveAuthenticatingHTTPProtocolDemo.xcodeproj/project.pbxproj
@@ -7,6 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0D45E5C9210F59FA007D7635 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D45E5C8210F59FA007D7635 /* AppDelegate.m */; };
+		0D45E5CC210F59FA007D7635 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D45E5CB210F59FA007D7635 /* ViewController.m */; };
+		0D45E5CF210F59FA007D7635 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0D45E5CD210F59FA007D7635 /* Main.storyboard */; };
+		0D45E5D1210F59FB007D7635 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0D45E5D0210F59FB007D7635 /* Assets.xcassets */; };
+		0D45E5D4210F59FB007D7635 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0D45E5D2210F59FB007D7635 /* LaunchScreen.storyboard */; };
+		0D45E5D7210F59FB007D7635 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D45E5D6210F59FB007D7635 /* main.m */; };
+		0D45E5DC210F5CA4007D7635 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0D45E5DB210F5CA3007D7635 /* WebKit.framework */; };
 		7F9F71FC0F99003C7CAB77FD /* libPods-JiveAuthenticatingHTTPProtocolDemo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37CC6806527D348D1828F7E0 /* libPods-JiveAuthenticatingHTTPProtocolDemo.a */; };
 		B0FE174BCA1FF0B5463184B8 /* libPods-JiveAuthenticatingHTTPProtocolDemoTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B082F53DF889EF1CCDD2EF6 /* libPods-JiveAuthenticatingHTTPProtocolDemoTests.a */; };
 		B8869C5A1AC44EDE005C12D9 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = B8869C591AC44EDE005C12D9 /* main.m */; };
@@ -29,6 +36,17 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0D45E5C5210F59FA007D7635 /* WKWebViewDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WKWebViewDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		0D45E5C7210F59FA007D7635 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		0D45E5C8210F59FA007D7635 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		0D45E5CA210F59FA007D7635 /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
+		0D45E5CB210F59FA007D7635 /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
+		0D45E5CE210F59FA007D7635 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		0D45E5D0210F59FB007D7635 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		0D45E5D3210F59FB007D7635 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		0D45E5D5210F59FB007D7635 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		0D45E5D6210F59FB007D7635 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		0D45E5DB210F5CA3007D7635 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 		37CC6806527D348D1828F7E0 /* libPods-JiveAuthenticatingHTTPProtocolDemo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-JiveAuthenticatingHTTPProtocolDemo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4385CA3947604E337671E67F /* Pods-JiveAuthenticatingHTTPProtocolDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JiveAuthenticatingHTTPProtocolDemo.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-JiveAuthenticatingHTTPProtocolDemo/Pods-JiveAuthenticatingHTTPProtocolDemo.debug.xcconfig"; sourceTree = "<group>"; };
 		4A2A4BE14767408AFD64036C /* Pods-JiveAuthenticatingHTTPProtocolDemoTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JiveAuthenticatingHTTPProtocolDemoTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-JiveAuthenticatingHTTPProtocolDemoTests/Pods-JiveAuthenticatingHTTPProtocolDemoTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -51,6 +69,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		0D45E5C2210F59FA007D7635 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0D45E5DC210F5CA4007D7635 /* WebKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B8869C511AC44EDE005C12D9 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -70,11 +96,28 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0D45E5C6210F59FA007D7635 /* WKWebViewDemo */ = {
+			isa = PBXGroup;
+			children = (
+				0D45E5C7210F59FA007D7635 /* AppDelegate.h */,
+				0D45E5C8210F59FA007D7635 /* AppDelegate.m */,
+				0D45E5CA210F59FA007D7635 /* ViewController.h */,
+				0D45E5CB210F59FA007D7635 /* ViewController.m */,
+				0D45E5CD210F59FA007D7635 /* Main.storyboard */,
+				0D45E5D0210F59FB007D7635 /* Assets.xcassets */,
+				0D45E5D2210F59FB007D7635 /* LaunchScreen.storyboard */,
+				0D45E5D5210F59FB007D7635 /* Info.plist */,
+				0D45E5D6210F59FB007D7635 /* main.m */,
+			);
+			path = WKWebViewDemo;
+			sourceTree = "<group>";
+		};
 		B8869C4B1AC44EDE005C12D9 = {
 			isa = PBXGroup;
 			children = (
 				B8869C561AC44EDE005C12D9 /* JiveAuthenticatingHTTPProtocolDemo */,
 				B8869C701AC44EDE005C12D9 /* JiveAuthenticatingHTTPProtocolDemoTests */,
+				0D45E5C6210F59FA007D7635 /* WKWebViewDemo */,
 				B8869C551AC44EDE005C12D9 /* Products */,
 				DC0D6C602AE8888BD2BBBFF3 /* Pods */,
 				E561E7E65EFD4E97C3678FDE /* Frameworks */,
@@ -86,6 +129,7 @@
 			children = (
 				B8869C541AC44EDE005C12D9 /* JiveAuthenticatingHTTPProtocolDemo.app */,
 				B8869C6D1AC44EDE005C12D9 /* JiveAuthenticatingHTTPProtocolDemoTests.xctest */,
+				0D45E5C5210F59FA007D7635 /* WKWebViewDemo.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -145,6 +189,7 @@
 		E561E7E65EFD4E97C3678FDE /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				0D45E5DB210F5CA3007D7635 /* WebKit.framework */,
 				37CC6806527D348D1828F7E0 /* libPods-JiveAuthenticatingHTTPProtocolDemo.a */,
 				8B082F53DF889EF1CCDD2EF6 /* libPods-JiveAuthenticatingHTTPProtocolDemoTests.a */,
 			);
@@ -154,6 +199,23 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		0D45E5C4210F59FA007D7635 /* WKWebViewDemo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0D45E5DA210F59FB007D7635 /* Build configuration list for PBXNativeTarget "WKWebViewDemo" */;
+			buildPhases = (
+				0D45E5C1210F59FA007D7635 /* Sources */,
+				0D45E5C2210F59FA007D7635 /* Frameworks */,
+				0D45E5C3210F59FA007D7635 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = WKWebViewDemo;
+			productName = WKWebViewDemo;
+			productReference = 0D45E5C5210F59FA007D7635 /* WKWebViewDemo.app */;
+			productType = "com.apple.product-type.application";
+		};
 		B8869C531AC44EDE005C12D9 /* JiveAuthenticatingHTTPProtocolDemo */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = B8869C771AC44EDE005C12D9 /* Build configuration list for PBXNativeTarget "JiveAuthenticatingHTTPProtocolDemo" */;
@@ -202,6 +264,10 @@
 				LastUpgradeCheck = 0620;
 				ORGANIZATIONNAME = "Heath Borders";
 				TargetAttributes = {
+					0D45E5C4210F59FA007D7635 = {
+						CreatedOnToolsVersion = 9.4.1;
+						ProvisioningStyle = Automatic;
+					};
 					B8869C531AC44EDE005C12D9 = {
 						CreatedOnToolsVersion = 6.2;
 					};
@@ -226,11 +292,22 @@
 			targets = (
 				B8869C531AC44EDE005C12D9 /* JiveAuthenticatingHTTPProtocolDemo */,
 				B8869C6C1AC44EDE005C12D9 /* JiveAuthenticatingHTTPProtocolDemoTests */,
+				0D45E5C4210F59FA007D7635 /* WKWebViewDemo */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		0D45E5C3210F59FA007D7635 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0D45E5D4210F59FB007D7635 /* LaunchScreen.storyboard in Resources */,
+				0D45E5D1210F59FB007D7635 /* Assets.xcassets in Resources */,
+				0D45E5CF210F59FA007D7635 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B8869C521AC44EDE005C12D9 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -314,6 +391,16 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		0D45E5C1210F59FA007D7635 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0D45E5CC210F59FA007D7635 /* ViewController.m in Sources */,
+				0D45E5D7210F59FB007D7635 /* main.m in Sources */,
+				0D45E5C9210F59FA007D7635 /* AppDelegate.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B8869C501AC44EDE005C12D9 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -343,6 +430,22 @@
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
+		0D45E5CD210F59FA007D7635 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				0D45E5CE210F59FA007D7635 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		0D45E5D2210F59FB007D7635 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				0D45E5D3210F59FB007D7635 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
 		B8869C611AC44EDE005C12D9 /* Main.storyboard */ = {
 			isa = PBXVariantGroup;
 			children = (
@@ -362,6 +465,75 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		0D45E5D8210F59FB007D7635 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = WKWebViewDemo/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.jivesoftware.WKWebViewDemo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		0D45E5D9210F59FB007D7635 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = WKWebViewDemo/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.jivesoftware.WKWebViewDemo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		B8869C751AC44EDE005C12D9 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -501,6 +673,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		0D45E5DA210F59FB007D7635 /* Build configuration list for PBXNativeTarget "WKWebViewDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0D45E5D8210F59FB007D7635 /* Debug */,
+				0D45E5D9210F59FB007D7635 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		B8869C4F1AC44EDE005C12D9 /* Build configuration list for PBXProject "JiveAuthenticatingHTTPProtocolDemo" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/JiveAuthenticatingHTTPProtocolDemo/JiveAuthenticatingHTTPProtocolDemo/ViewController.m
+++ b/JiveAuthenticatingHTTPProtocolDemo/JiveAuthenticatingHTTPProtocolDemo/ViewController.m
@@ -36,7 +36,19 @@
 #pragma mark - JAHPAuthenticatingHTTPProtocolDelegate
 
 - (BOOL)authenticatingHTTPProtocol:(JAHPAuthenticatingHTTPProtocol *)authenticatingHTTPProtocol canAuthenticateAgainstProtectionSpace:(NSURLProtectionSpace *)protectionSpace {
-    BOOL canAuthenticate = [protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodHTTPBasic];
+
+    NSArray* interceptedAuthMethods =
+    @[
+        NSURLAuthenticationMethodHTTPBasic
+      , NSURLAuthenticationMethodHTTPDigest
+      , NSURLAuthenticationMethodNTLM
+    ];
+    
+    NSSet* interceptedAuthMethodsSet = [NSSet setWithArray: interceptedAuthMethods];
+    
+    BOOL canAuthenticate =
+    [interceptedAuthMethodsSet containsObject: protectionSpace.authenticationMethod];
+    
     return canAuthenticate;
 }
 

--- a/JiveAuthenticatingHTTPProtocolDemo/JiveAuthenticatingHTTPProtocolDemo/ViewController.m
+++ b/JiveAuthenticatingHTTPProtocolDemo/JiveAuthenticatingHTTPProtocolDemo/ViewController.m
@@ -30,7 +30,7 @@
     [JAHPAuthenticatingHTTPProtocol setDelegate:self];
     [JAHPAuthenticatingHTTPProtocol start];
     self.webView.delegate = self;
-    [self.webView loadRequest:[[NSURLRequest alloc] initWithURL:[NSURL URLWithString:@"http://httpbin.org/basic-auth/foo/bar"]]];
+    [self.webView loadRequest:[[NSURLRequest alloc] initWithURL:[NSURL URLWithString:@"https://httpbin.org/basic-auth/foo/bar"]]];
 }
 
 #pragma mark - JAHPAuthenticatingHTTPProtocolDelegate
@@ -127,7 +127,7 @@
 // Then all logs will go to the `authenticatingHTTPProtocol:logMessage:` method
 //
 //- (void)authenticatingHTTPProtocol:(JAHPAuthenticatingHTTPProtocol *)authenticatingHTTPProtocol logWithFormat:(NSString *)format arguments:(va_list)arguments {
-//    
+//
 //    NSLog(@"logWithFormat: %@", [[NSString alloc] initWithFormat:format arguments:arguments]);
 //}
 

--- a/JiveAuthenticatingHTTPProtocolDemo/WKWebViewDemo/AppDelegate.h
+++ b/JiveAuthenticatingHTTPProtocolDemo/WKWebViewDemo/AppDelegate.h
@@ -1,0 +1,17 @@
+//
+//  AppDelegate.h
+//  WKWebViewDemo
+//
+//  Created by Alexander Dodatko on 7/30/18.
+//  Copyright © 2018 Heath Borders. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+@property (strong, nonatomic) UIWindow *window;
+
+
+@end
+

--- a/JiveAuthenticatingHTTPProtocolDemo/WKWebViewDemo/AppDelegate.m
+++ b/JiveAuthenticatingHTTPProtocolDemo/WKWebViewDemo/AppDelegate.m
@@ -1,0 +1,51 @@
+//
+//  AppDelegate.m
+//  WKWebViewDemo
+//
+//  Created by Alexander Dodatko on 7/30/18.
+//  Copyright © 2018 Heath Borders. All rights reserved.
+//
+
+#import "AppDelegate.h"
+
+@interface AppDelegate ()
+
+@end
+
+@implementation AppDelegate
+
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    // Override point for customization after application launch.
+    return YES;
+}
+
+
+- (void)applicationWillResignActive:(UIApplication *)application {
+    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+    // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
+}
+
+
+- (void)applicationDidEnterBackground:(UIApplication *)application {
+    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+    // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+}
+
+
+- (void)applicationWillEnterForeground:(UIApplication *)application {
+    // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
+}
+
+
+- (void)applicationDidBecomeActive:(UIApplication *)application {
+    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+}
+
+
+- (void)applicationWillTerminate:(UIApplication *)application {
+    // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+}
+
+
+@end

--- a/JiveAuthenticatingHTTPProtocolDemo/WKWebViewDemo/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/JiveAuthenticatingHTTPProtocolDemo/WKWebViewDemo/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/JiveAuthenticatingHTTPProtocolDemo/WKWebViewDemo/Assets.xcassets/Contents.json
+++ b/JiveAuthenticatingHTTPProtocolDemo/WKWebViewDemo/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/JiveAuthenticatingHTTPProtocolDemo/WKWebViewDemo/Base.lproj/LaunchScreen.storyboard
+++ b/JiveAuthenticatingHTTPProtocolDemo/WKWebViewDemo/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" systemVersion="17A277" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/JiveAuthenticatingHTTPProtocolDemo/WKWebViewDemo/Base.lproj/Main.storyboard
+++ b/JiveAuthenticatingHTTPProtocolDemo/WKWebViewDemo/Base.lproj/Main.storyboard
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="U0A-g0-j66">
+                                <rect key="frame" x="0.0" y="26" width="375" height="641"/>
+                                <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <wkWebViewConfiguration key="configuration">
+                                    <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
+                                    <wkPreferences key="preferences"/>
+                                </wkWebViewConfiguration>
+                            </wkWebView>
+                        </subviews>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstItem="U0A-g0-j66" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="ABy-6P-nJe"/>
+                            <constraint firstItem="U0A-g0-j66" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="6" id="Jkz-gX-vUO"/>
+                            <constraint firstItem="U0A-g0-j66" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="Pvn-Fj-TMy"/>
+                            <constraint firstItem="U0A-g0-j66" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="TAa-0h-hkF"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                    <connections>
+                        <outlet property="webView" destination="U0A-g0-j66" id="5b5-Hl-jUm"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="136.80000000000001" y="133.5832083958021"/>
+        </scene>
+    </scenes>
+</document>

--- a/JiveAuthenticatingHTTPProtocolDemo/WKWebViewDemo/Base.lproj/Main.storyboard
+++ b/JiveAuthenticatingHTTPProtocolDemo/WKWebViewDemo/Base.lproj/Main.storyboard
@@ -17,28 +17,9 @@
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="U0A-g0-j66">
-                                <rect key="frame" x="0.0" y="26" width="375" height="641"/>
-                                <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <wkWebViewConfiguration key="configuration">
-                                    <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
-                                    <wkPreferences key="preferences"/>
-                                </wkWebViewConfiguration>
-                            </wkWebView>
-                        </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <constraints>
-                            <constraint firstItem="U0A-g0-j66" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="ABy-6P-nJe"/>
-                            <constraint firstItem="U0A-g0-j66" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="6" id="Jkz-gX-vUO"/>
-                            <constraint firstItem="U0A-g0-j66" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="Pvn-Fj-TMy"/>
-                            <constraint firstItem="U0A-g0-j66" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="TAa-0h-hkF"/>
-                        </constraints>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
-                    <connections>
-                        <outlet property="webView" destination="U0A-g0-j66" id="5b5-Hl-jUm"/>
-                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/JiveAuthenticatingHTTPProtocolDemo/WKWebViewDemo/Info.plist
+++ b/JiveAuthenticatingHTTPProtocolDemo/WKWebViewDemo/Info.plist
@@ -2,6 +2,52 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        
+        <key>NSAllowsArbitraryLoads</key>
+        <true/>
+        
+        <key>NSAllowsArbitraryLoadsInWebContent</key>
+        <true/>
+        
+        
+        <key>NSAllowsArbitraryLoadsForMedia</key>
+        <true/>
+        
+        
+        <key>NSExceptionDomains</key>
+        <dict>
+            
+            
+            <key>some.http.host</key>
+            <dict>
+                <key>NSIncludesSubdomains</key>
+                <true/>
+                
+                <key>NSExceptionAllowsInsecureHTTPLoads</key>
+                <true/>
+                
+                <key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
+                <true/>
+                
+                
+                
+                <key>NSExceptionRequiresForwardSecrecy</key>
+                <true/>
+                <key>NSExceptionMinimumTLSVersion</key>
+                <string>TLSv1.2</string>
+                <key>NSThirdPartyExceptionRequiresForwardSecrecy</key>
+                <true/>
+                <key>NSThirdPartyExceptionMinimumTLSVersion</key>
+                <string>TLSv1.2</string>
+                <key>NSRequiresCertificateTransparency</key>
+                <false/>
+            </dict>
+        </dict>
+            
+    </dict>
+    
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/JiveAuthenticatingHTTPProtocolDemo/WKWebViewDemo/Info.plist
+++ b/JiveAuthenticatingHTTPProtocolDemo/WKWebViewDemo/Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/JiveAuthenticatingHTTPProtocolDemo/WKWebViewDemo/ViewController.h
+++ b/JiveAuthenticatingHTTPProtocolDemo/WKWebViewDemo/ViewController.h
@@ -1,0 +1,15 @@
+//
+//  ViewController.h
+//  WKWebViewDemo
+//
+//  Created by Alexander Dodatko on 7/30/18.
+//  Copyright © 2018 Heath Borders. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface ViewController : UIViewController
+
+
+@end
+

--- a/JiveAuthenticatingHTTPProtocolDemo/WKWebViewDemo/ViewController.m
+++ b/JiveAuthenticatingHTTPProtocolDemo/WKWebViewDemo/ViewController.m
@@ -20,7 +20,7 @@ typedef void (^WKWebViewAuthChallengeBlock)(
 , WKNavigationDelegate
 >
 
-@property (nonatomic, weak) IBOutlet WKWebView *webView;
+@property (nonatomic, weak) WKWebView *webView;
 @property (nonatomic, strong) UIAlertView *authAlertView;
 @property (nonatomic, copy) WKWebViewAuthChallengeBlock webViewChallengeBlock;
 
@@ -35,7 +35,32 @@ typedef void (^WKWebViewAuthChallengeBlock)(
 - (void)viewDidLoad {
     [super viewDidLoad];
     
+    
+    
+    WKWebViewConfiguration* config = [WKWebViewConfiguration new];
+    config.allowsInlineMediaPlayback = YES;
+    config.allowsPictureInPictureMediaPlayback = NO;
+    config.mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeAll;
+    
+    CGRect fullScreen = self.view.bounds;
+    WKWebView* webView = [[WKWebView alloc] initWithFrame: fullScreen
+                                            configuration: config];
+    self.webView = webView;
+    
+    webView.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.view addSubview: webView];
+    
+    [NSLayoutConstraint activateConstraints:
+    @[
+     [webView.topAnchor    constraintEqualToAnchor: self.topLayoutGuide.bottomAnchor],
+     [webView.bottomAnchor constraintEqualToAnchor: self.bottomLayoutGuide.topAnchor],
+     [webView.leftAnchor   constraintEqualToAnchor: self.view.leftAnchor            ],
+     [webView.rightAnchor  constraintEqualToAnchor: self.view.rightAnchor           ]
+    ]];
+    
+
     self.webView.navigationDelegate = self;
+    
     
     NSString* txtUrl = @"https://httpbin.org/basic-auth/foo/bar";
     NSURL* url = [NSURL URLWithString: txtUrl];

--- a/JiveAuthenticatingHTTPProtocolDemo/WKWebViewDemo/ViewController.m
+++ b/JiveAuthenticatingHTTPProtocolDemo/WKWebViewDemo/ViewController.m
@@ -36,11 +36,16 @@ typedef void (^WKWebViewAuthChallengeBlock)(
     [super viewDidLoad];
     
     
+    // https://github.com/cyyuen/ADCookieIsolatedWebView
+    // https://github.com/jjconti/swift-webview-isolated
+    //
+    //
     
     WKWebViewConfiguration* config = [WKWebViewConfiguration new];
     config.allowsInlineMediaPlayback = YES;
     config.allowsPictureInPictureMediaPlayback = NO;
     config.mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeAll;
+    config.websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
     
     CGRect fullScreen = self.view.bounds;
     WKWebView* webView = [[WKWebView alloc] initWithFrame: fullScreen
@@ -60,8 +65,7 @@ typedef void (^WKWebViewAuthChallengeBlock)(
     
 
     self.webView.navigationDelegate = self;
-    
-    
+        
     NSString* txtUrl = @"https://httpbin.org/basic-auth/foo/bar";
     NSURL* url = [NSURL URLWithString: txtUrl];
     NSURLRequest* request = [[NSURLRequest alloc] initWithURL: url];

--- a/JiveAuthenticatingHTTPProtocolDemo/WKWebViewDemo/ViewController.m
+++ b/JiveAuthenticatingHTTPProtocolDemo/WKWebViewDemo/ViewController.m
@@ -1,0 +1,143 @@
+//
+//  ViewController.m
+//  JiveAuthenticatingHTTPProtocolDemo
+//
+//  Created by Heath Borders on 3/26/15.
+//  Copyright (c) 2015 Jive Software. All rights reserved.
+//
+
+#import "ViewController.h"
+
+#import <WebKit/WebKit.h>
+
+typedef void (^WKWebViewAuthChallengeBlock)(
+    NSURLSessionAuthChallengeDisposition,
+    NSURLCredential * _Nullable);
+
+@interface ViewController ()
+<
+  UIAlertViewDelegate
+, WKNavigationDelegate
+>
+
+@property (nonatomic, weak) IBOutlet WKWebView *webView;
+@property (nonatomic, strong) UIAlertView *authAlertView;
+@property (nonatomic, copy) WKWebViewAuthChallengeBlock webViewChallengeBlock;
+
+@property (nonatomic, strong) NSURLCredential* userInput;
+
+@end
+
+@implementation ViewController
+
+#pragma mark - UIViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    
+    self.webView.navigationDelegate = self;
+    [self.webView loadRequest:[[NSURLRequest alloc] initWithURL:[NSURL URLWithString:@"https://httpbin.org/basic-auth/foo/bar"]]];
+}
+
+#pragma mark - JAHPAuthenticatingHTTPProtocolDelegate
+- (BOOL)shouldShowDialogForAuthorizationMethod:(NSString*)authorizationMethod
+{
+    NSArray* interceptedAuthMethods =
+    @[
+        NSURLAuthenticationMethodHTTPBasic
+      , NSURLAuthenticationMethodHTTPDigest
+      , NSURLAuthenticationMethodNTLM
+    ];
+    
+    NSSet* interceptedAuthMethodsSet = [NSSet setWithArray: interceptedAuthMethods];
+    
+    BOOL canAuthenticate =
+        [interceptedAuthMethodsSet containsObject: authorizationMethod];
+    
+    return canAuthenticate;
+}
+
+#pragma mark - UIAlertViewDelegate
+
+- (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex {
+    if (buttonIndex == self.authAlertView.cancelButtonIndex) {
+        [self cancelChallengeAfterAlertViewDismissal];
+    } else if (buttonIndex == self.authAlertView.firstOtherButtonIndex) {
+        [self useAuthAlertViewUsernamePasswordForChallenge];
+    }
+}
+
+- (void)alertViewCancel:(UIAlertView *)alertView {
+    [self cancelChallengeAfterAlertViewDismissal];
+}
+
+#pragma mark - WKWebViewDelegate
+-(void)webView:(WKWebView *)webView
+didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge
+completionHandler:(WKWebViewAuthChallengeBlock)completionHandler
+{
+    NSString* authMethod = [[challenge protectionSpace] authenticationMethod];
+    BOOL shouldIntercept = [self shouldShowDialogForAuthorizationMethod: authMethod];
+    
+    if (!shouldIntercept)
+    {
+        completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
+        return;
+    }
+    
+    if (nil != self.userInput)
+    {
+        completionHandler(NSURLSessionAuthChallengeUseCredential, self.userInput);
+        return;
+    }
+    
+    //=== show alert
+    //
+    self.webViewChallengeBlock = completionHandler;
+    
+    self.authAlertView = [[UIAlertView alloc] initWithTitle:@"JAHPDemo"
+                                                    message:@"Enter 'foo' for the username and 'bar' for the password"
+                                                   delegate:self
+                                          cancelButtonTitle:@"Cancel"
+                                          otherButtonTitles:
+                          @"OK",
+                          nil];
+    self.authAlertView.alertViewStyle = UIAlertViewStyleLoginAndPasswordInput;
+    [self.authAlertView show];
+}
+
+
+#pragma mark - Private API
+
+- (void)cancelChallengeAfterAlertViewDismissal
+{
+    if (nil != self.webViewChallengeBlock)
+    {
+        self.webViewChallengeBlock(NSURLSessionAuthChallengeCancelAuthenticationChallenge, nil);
+    }
+    
+    self.authAlertView = nil;
+}
+
+- (void)useAuthAlertViewUsernamePasswordForChallenge {
+    NSString *username = [self.authAlertView textFieldAtIndex:0].text;
+    NSString *password = [self.authAlertView textFieldAtIndex:1].text;
+    self.authAlertView = nil;
+    NSURLCredential *credential = [NSURLCredential credentialWithUser:username
+                                                             password:password
+                                                          persistence:NSURLCredentialPersistenceNone];
+    self.userInput = credential;
+    
+    
+    [self passCredentialsInputToConnection];
+}
+
+-(void)passCredentialsInputToConnection {
+    
+    NSParameterAssert(nil != self.userInput);
+    NSParameterAssert(nil != self.webViewChallengeBlock);
+    
+    self.webViewChallengeBlock(NSURLSessionAuthChallengeUseCredential, self.userInput);
+}
+
+@end

--- a/JiveAuthenticatingHTTPProtocolDemo/WKWebViewDemo/ViewController.m
+++ b/JiveAuthenticatingHTTPProtocolDemo/WKWebViewDemo/ViewController.m
@@ -90,7 +90,6 @@ typedef void (^WKWebViewAuthChallengeBlock)(
     [self.webView loadRequest: request];
 }
 
-#pragma mark - JAHPAuthenticatingHTTPProtocolDelegate
 - (BOOL)shouldShowDialogForAuthorizationMethod:(NSString*)authorizationMethod
 {
     NSLog(@"shouldShowDialogForAuthorizationMethod: %@", authorizationMethod);

--- a/JiveAuthenticatingHTTPProtocolDemo/WKWebViewDemo/ViewController.m
+++ b/JiveAuthenticatingHTTPProtocolDemo/WKWebViewDemo/ViewController.m
@@ -36,7 +36,11 @@ typedef void (^WKWebViewAuthChallengeBlock)(
     [super viewDidLoad];
     
     self.webView.navigationDelegate = self;
-    [self.webView loadRequest:[[NSURLRequest alloc] initWithURL:[NSURL URLWithString:@"https://httpbin.org/basic-auth/foo/bar"]]];
+    
+    NSString* txtUrl = @"https://httpbin.org/basic-auth/foo/bar";
+    NSURL* url = [NSURL URLWithString: txtUrl];
+    NSURLRequest* request = [[NSURLRequest alloc] initWithURL: url];
+    [self.webView loadRequest: request];
 }
 
 #pragma mark - JAHPAuthenticatingHTTPProtocolDelegate

--- a/JiveAuthenticatingHTTPProtocolDemo/WKWebViewDemo/main.m
+++ b/JiveAuthenticatingHTTPProtocolDemo/WKWebViewDemo/main.m
@@ -1,0 +1,16 @@
+//
+//  main.m
+//  WKWebViewDemo
+//
+//  Created by Alexander Dodatko on 7/30/18.
+//  Copyright © 2018 Heath Borders. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "AppDelegate.h"
+
+int main(int argc, char * argv[]) {
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+    }
+}

--- a/README.md
+++ b/README.md
@@ -4,11 +4,66 @@ JiveAuthenticatingHTTPProtocol
 Based on [Apple's CustomHTTPProtocol](https://developer.apple.com/library/prerelease/ios/samplecode/CustomHTTPProtocol/Introduction/Intro.html),
 `JiveAuthenticatingHTTPProtocol` provides authentication callbacks for a `UIWebView`.
 
+#### Note :
+
+```
+No cleanup of the sample code has been done, so there might be some strange "patterns" inside. 
+```
+
+See https://github.com/jivesoftware/JiveAuthenticatingHTTPProtocol/issues/3 for more details.
+
+
 Usage
 -----
-`JiveAuthenticatingHTTPProtocol` captures all `NSURLConnection` traffic. Ensure that no other `NSURLConnection`s can start after you call `+[JAHPAuthenticatingHTTPProtocol start]`. Before loading an `NSURLRequest` that may require handling an authentication callback, call `+[JAHPAuthenticatingHTTPProtocol setDelegate:]`, then `+[JAHPAuthenticatingHTTPProtocol start]`. Finally, load your `NSURLRequest`, and handle the callbacks from `JAHPAuthenticatingHTTPProtocolDelegate`.
+`JiveAuthenticatingHTTPProtocol` captures all `NSURLConnection` traffic. 
 
-See JiveAuthenticatingHTTPProtocolDemo/ViewController.m for an example.
+1. Ensure that no other `NSURLConnection`s can start after you call `+[JAHPAuthenticatingHTTPProtocol start]`. 
+2. Before loading an `NSURLRequest` that may require handling an authentication callback, call `+[JAHPAuthenticatingHTTPProtocol setDelegate:]`, 
+3. Then call `+[JAHPAuthenticatingHTTPProtocol start]`. 
+4. Finally, load your `NSURLRequest`, and handle the callbacks from `JAHPAuthenticatingHTTPProtocolDelegate`.
+
+See `JiveAuthenticatingHTTPProtocolDemo/ViewController.m` for an example.
+
+It might be a good idea to memoize the credentials entered by the user to avoid "spamming" them with the data input alerts. This is an absolute "must" if your page contains the video which requires authorization.
+
+
+
+Supported Authorization Methods
+-----
+This library supports all of the authentication schemes `NSURLAuthentication` supports.
+
+This has been tested with `NTLM` and `ADFS` authentication, (which `NSURLAuthentication` natively supports). Basically, if an authentication method works in `Safari`, it'll probably work here, too.
+
+You can add more authorization methods like this :
+
+```obj-c
+- (BOOL)authenticatingHTTPProtocol:(JAHPAuthenticatingHTTPProtocol *)authenticatingHTTPProtocol
+canAuthenticateAgainstProtectionSpace:(NSURLProtectionSpace *)protectionSpace
+{
+    NSArray* interceptedAuthMethods =
+    @[
+      NSURLAuthenticationMethodHTTPBasic
+      , NSURLAuthenticationMethodNTLM
+    ];
+    
+    NSSet* interceptedAuthMethodsSet = [NSSet setWithArray: interceptedAuthMethods];
+    
+    BOOL canAuthenticate =
+        [interceptedAuthMethodsSet containsObject: protectionSpace.authenticationMethod];
+    
+    return canAuthenticate;
+}
+```
+
+
+#### Caution : 
+
+```
+Stubbing the above function to always return "true" is not always a good idea.
+If you do so, it would be your responsibility to implement all the required handshakes.
+```
+
+
 
 License
 -------

--- a/Source/JiveAuthenticatingHTTPProtocol/JAHPAuthenticatingHTTPProtocol.m
+++ b/Source/JiveAuthenticatingHTTPProtocol/JAHPAuthenticatingHTTPProtocol.m
@@ -253,9 +253,9 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
     // NSURLProtocol subclass.
     
     if (shouldAccept) {
-        shouldAccept = YES && [scheme isEqual:@"http"];
+        shouldAccept = [scheme isEqual:@"http"];
         if ( ! shouldAccept ) {
-            shouldAccept = YES && [scheme isEqual:@"https"];
+            shouldAccept = [scheme isEqual:@"https"];
         }
         
         if ( ! shouldAccept ) {

--- a/Source/JiveAuthenticatingHTTPProtocol/JAHPAuthenticatingHTTPProtocol.m
+++ b/Source/JiveAuthenticatingHTTPProtocol/JAHPAuthenticatingHTTPProtocol.m
@@ -272,7 +272,7 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
 {
     NSURLRequest *      result;
     
-    assert(request != nil);
+    NSParameterAssert(request != nil);
     // can be called on any thread
     
     // Canonicalising a request is quite complex, so all the heavy lifting has
@@ -287,9 +287,9 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
 
 - (id)initWithRequest:(NSURLRequest *)request cachedResponse:(NSCachedURLResponse *)cachedResponse client:(id <NSURLProtocolClient>)client
 {
-    assert(request != nil);
+    NSParameterAssert(request != nil);
     // cachedResponse may be nil
-    assert(client != nil);
+    NSParameterAssert(client != nil);
     // can be called on any thread
     
     NSMutableURLRequest *mutableRequest = [request mutableCopy];
@@ -327,9 +327,9 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
 {
     // can be called on any thread
     [[self class] authenticatingHTTPProtocol:self logWithFormat:@"dealloc"];
-    assert(self->_task == nil);                     // we should have cleared it by now
-    assert(self->_pendingChallenge == nil);         // we should have cancelled it by now
-    assert(self->_pendingChallengeCompletionHandler == nil);    // we should have cancelled it by now
+    NSParameterAssert(self->_task == nil);                     // we should have cleared it by now
+    NSParameterAssert(self->_pendingChallenge == nil);         // we should have cancelled it by now
+    NSParameterAssert(self->_pendingChallengeCompletionHandler == nil);    // we should have cancelled it by now
 }
 
 - (void)startLoading
@@ -341,8 +341,8 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
     // At this point we kick off the process of loading the URL via NSURLSession.
     // The thread that calls this method becomes the client thread.
     
-    assert(self.clientThread == nil);           // you can't call -startLoading twice
-    assert(self.task == nil);
+    NSParameterAssert(self.clientThread == nil);           // you can't call -startLoading twice
+    NSParameterAssert(self.task == nil);
     
     // Calculate our effective run loop modes.  In some circumstances (yes I'm looking at
     // you UIWebView!) we can be called from a non-standard thread which then runs a
@@ -353,7 +353,7 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
     // For debugging purposes the non-standard mode is "WebCoreSynchronousLoaderRunLoopMode"
     // but it's better not to hard-code that here.
     
-    assert(self.modes == nil);
+    NSParameterAssert(self.modes == nil);
     calculatedModes = [NSMutableArray array];
     [calculatedModes addObject:NSDefaultRunLoopMode];
     currentMode = [[NSRunLoop currentRunLoop] currentMode];
@@ -361,13 +361,13 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
         [calculatedModes addObject:currentMode];
     }
     self.modes = calculatedModes;
-    assert([self.modes count] > 0);
+    NSParameterAssert([self.modes count] > 0);
     
     // Create new request that's a clone of the request we were initialised with,
     // except that it has our 'recursive request flag' property set on it.
     
     recursiveRequest = [[self request] mutableCopy];
-    assert(recursiveRequest != nil);
+    NSParameterAssert(recursiveRequest != nil);
     
     [[self class] setProperty:@YES forKey:kJAHPRecursiveRequestFlagProperty inRequest:recursiveRequest];
     
@@ -385,7 +385,7 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
     // Once everything is ready to go, create a data task with the new request.
     
     self.task = [[[self class] sharedDemux] dataTaskWithRequest:recursiveRequest delegate:self modes:self.modes];
-    assert(self.task != nil);
+    NSParameterAssert(self.task != nil);
     
     [self.task resume];
 }
@@ -396,7 +396,7 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
     
     [[self class] authenticatingHTTPProtocol:self logWithFormat:@"stop (elapsed %.1f)", [NSDate timeIntervalSinceReferenceDate] - self.startTime];
     
-    assert(self.clientThread != nil);           // someone must have called -startLoading
+    NSParameterAssert(self.clientThread != nil);           // someone must have called -startLoading
     
     // Check that we're being stopped on the same thread that we were started
     // on.  Without this invariant things are going to go badly (for example,
@@ -408,7 +408,7 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
     // Rather, I rely on our client calling us on the right thread, which is what
     // the following assert is about.
     
-    assert([NSThread currentThread] == self.clientThread);
+    NSParameterAssert([NSThread currentThread] == self.clientThread);
     
     [self cancelPendingChallenge];
     if (self.task != nil) {
@@ -432,7 +432,7 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
 {
     // thread may be nil
     // modes may be nil
-    assert(block != nil);
+    NSParameterAssert(block != nil);
     
     if (thread == nil) {
         thread = [NSThread mainThread];
@@ -450,7 +450,7 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
 
 - (void)onThreadPerformBlock:(dispatch_block_t)block
 {
-    assert(block != nil);
+    NSParameterAssert(block != nil);
     block();
 }
 
@@ -475,9 +475,9 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
 
 - (void)didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(JAHPChallengeCompletionHandler)completionHandler
 {
-    assert(challenge != nil);
-    assert(completionHandler != nil);
-    assert([NSThread currentThread] == self.clientThread);
+    NSParameterAssert(challenge != nil);
+    NSParameterAssert(completionHandler != nil);
+    NSParameterAssert([NSThread currentThread] == self.clientThread);
     
     [[self class] authenticatingHTTPProtocol:self logWithFormat:@"challenge %@ received", [[challenge protectionSpace] authenticationMethod]];
     
@@ -498,9 +498,9 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
 
 - (void)mainThreadDidReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(JAHPChallengeCompletionHandler)completionHandler
 {
-    assert(challenge != nil);
-    assert(completionHandler != nil);
-    assert([NSThread isMainThread]);
+    NSParameterAssert(challenge != nil);
+    NSParameterAssert(completionHandler != nil);
+    NSParameterAssert([NSThread isMainThread]);
     
     if (self.pendingChallenge != nil) {
         
@@ -512,7 +512,7 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
         // namely, the client thread.
         
         [[self class] authenticatingHTTPProtocol:self logWithFormat:@"challenge %@ cancelled; other challenge pending", [[challenge protectionSpace] authenticationMethod]];
-        assert(NO);
+        NSParameterAssert(NO);
         [self clientThreadCancelAuthenticationChallenge:challenge completionHandler:completionHandler];
     } else {
         id<JAHPAuthenticatingHTTPProtocolDelegate>  strongDelegate;
@@ -526,7 +526,7 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
         
         if ( ! [strongDelegate respondsToSelector:@selector(authenticatingHTTPProtocol:canAuthenticateAgainstProtectionSpace:)] ) {
             [[self class] authenticatingHTTPProtocol:self logWithFormat:@"challenge %@ cancelled; no delegate method", [[challenge protectionSpace] authenticationMethod]];
-            assert(NO);
+            NSParameterAssert(NO);
             [self clientThreadCancelAuthenticationChallenge:challenge completionHandler:completionHandler];
         } else {
             
@@ -556,9 +556,9 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
 - (void)clientThreadCancelAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(JAHPChallengeCompletionHandler)completionHandler
 {
 #pragma unused(challenge)
-    assert(challenge != nil);
-    assert(completionHandler != nil);
-    assert([NSThread isMainThread]);
+    NSParameterAssert(challenge != nil);
+    NSParameterAssert(completionHandler != nil);
+    NSParameterAssert([NSThread isMainThread]);
     
     [self performOnThread:self.clientThread modes:self.modes block:^{
         completionHandler(NSURLSessionAuthChallengeCancelAuthenticationChallenge, nil);
@@ -574,7 +574,7 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
 
 - (void)cancelPendingChallenge
 {
-    assert([NSThread currentThread] == self.clientThread);
+    NSParameterAssert([NSThread currentThread] == self.clientThread);
     
     // Just pass the work off to the main thread.  We do this so that all accesses
     // to pendingChallenge are done from the main thread, which avoids the need for
@@ -613,7 +613,7 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
                 [[self class] authenticatingHTTPProtocol:self logWithFormat:@"challenge %@ cancellation failed; no delegate method", [[challenge protectionSpace] authenticationMethod]];
                 // If we managed to send a challenge to the client but can't cancel it, that's bad.
                 // There's nothing we can do at this point except log the problem.
-                assert(NO);
+                NSParameterAssert(NO);
             }
         }
     }];
@@ -622,8 +622,8 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
 - (void)resolvePendingAuthenticationChallengeWithCredential:(NSURLCredential *)credential
 {
     // credential may be nil
-    assert([NSThread isMainThread]);
-    assert(self.clientThread != nil);
+    NSParameterAssert([NSThread isMainThread]);
+    NSParameterAssert(self.clientThread != nil);
     
     JAHPChallengeCompletionHandler  completionHandler;
     NSURLAuthenticationChallenge *challenge;
@@ -650,8 +650,8 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
 }
 
 - (void)cancelPendingAuthenticationChallenge {
-    assert([NSThread isMainThread]);
-    assert(self.clientThread != nil);
+    NSParameterAssert([NSThread isMainThread]);
+    NSParameterAssert(self.clientThread != nil);
     
     JAHPChallengeCompletionHandler  completionHandler;
     NSURLAuthenticationChallenge *challenge;
@@ -690,12 +690,12 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
     
 #pragma unused(session)
 #pragma unused(task)
-    assert(task == self.task);
-    assert(response != nil);
-    assert(newRequest != nil);
+    NSParameterAssert(task == self.task);
+    NSParameterAssert(response != nil);
+    NSParameterAssert(newRequest != nil);
 #pragma unused(completionHandler)
-    assert(completionHandler != nil);
-    assert([NSThread currentThread] == self.clientThread);
+    NSParameterAssert(completionHandler != nil);
+    NSParameterAssert([NSThread currentThread] == self.clientThread);
     
     [[self class] authenticatingHTTPProtocol:self logWithFormat:@"will redirect from %@ to %@", [response URL], [newRequest URL]];
     
@@ -707,7 +707,7 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
     // We also cancel our current connection because the client is going to start a new request for
     // us anyway.
     
-    assert([[self class] propertyForKey:kJAHPRecursiveRequestFlagProperty inRequest:newRequest] != nil);
+    NSParameterAssert([[self class] propertyForKey:kJAHPRecursiveRequestFlagProperty inRequest:newRequest] != nil);
     
     redirectRequest = [newRequest mutableCopy];
     [[self class] removePropertyForKey:kJAHPRecursiveRequestFlagProperty inRequest:redirectRequest];
@@ -742,10 +742,10 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
     
 #pragma unused(session)
 #pragma unused(task)
-    assert(task == self.task);
-    assert(challenge != nil);
-    assert(completionHandler != nil);
-    assert([NSThread currentThread] == self.clientThread);
+    NSParameterAssert(task == self.task);
+    NSParameterAssert(challenge != nil);
+    NSParameterAssert(completionHandler != nil);
+    NSParameterAssert([NSThread currentThread] == self.clientThread);
     
     // Ask our delegate whether it wants this challenge.  We do this from this thread, not the main thread,
     // to avoid the overload of bouncing to the main thread for challenges that aren't going to be customised
@@ -786,10 +786,10 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
     
 #pragma unused(session)
 #pragma unused(dataTask)
-    assert(dataTask == self.task);
-    assert(response != nil);
-    assert(completionHandler != nil);
-    assert([NSThread currentThread] == self.clientThread);
+    NSParameterAssert(dataTask == self.task);
+    NSParameterAssert(response != nil);
+    NSParameterAssert(completionHandler != nil);
+    NSParameterAssert([NSThread currentThread] == self.clientThread);
     
     // Pass the call on to our client.  The only tricky thing is that we have to decide on a
     // cache storage policy, which is based on the actual request we issued, not the request
@@ -799,7 +799,7 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
         cacheStoragePolicy = JAHPCacheStoragePolicyForRequestAndResponse(self.task.originalRequest, (NSHTTPURLResponse *) response);
         statusCode = [((NSHTTPURLResponse *) response) statusCode];
     } else {
-        assert(NO);
+        NSParameterAssert(NO);
         cacheStoragePolicy = NSURLCacheStorageNotAllowed;
         statusCode = 42;
     }
@@ -823,9 +823,9 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
     
 #pragma unused(session)
 #pragma unused(dataTask)
-    assert(dataTask == self.task);
-    assert(data != nil);
-    assert([NSThread currentThread] == self.clientThread);
+    NSParameterAssert(dataTask == self.task);
+    NSParameterAssert(data != nil);
+    NSParameterAssert([NSThread currentThread] == self.clientThread);
     
     // Just pass the call on to our client.
     
@@ -846,10 +846,10 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
     
 #pragma unused(session)
 #pragma unused(dataTask)
-    assert(dataTask == self.task);
-    assert(proposedResponse != nil);
-    assert(completionHandler != nil);
-    assert([NSThread currentThread] == self.clientThread);
+    NSParameterAssert(dataTask == self.task);
+    NSParameterAssert(proposedResponse != nil);
+    NSParameterAssert(completionHandler != nil);
+    NSParameterAssert([NSThread currentThread] == self.clientThread);
     
     // We implement this delegate callback purely for the purposes of logging.
     
@@ -863,8 +863,8 @@ static NSString * kJAHPRecursiveRequestFlagProperty = @"com.jivesoftware.JAHPAut
 {
 #pragma unused(session)
 #pragma unused(task)
-    assert( (self.task == nil) || (task == self.task) );        // can be nil in the 'cancel from -stopLoading' case
-    assert([NSThread currentThread] == self.clientThread);
+    NSParameterAssert( (self.task == nil) || (task == self.task) );        // can be nil in the 'cancel from -stopLoading' case
+    NSParameterAssert([NSThread currentThread] == self.clientThread);
     
     // Just log and then, in most cases, pass the call on to our client.
     

--- a/Source/JiveAuthenticatingHTTPProtocol/JAHPCacheStoragePolicy.h
+++ b/Source/JiveAuthenticatingHTTPProtocol/JAHPCacheStoragePolicy.h
@@ -58,4 +58,4 @@
  *  \returns A cache storage policy to use.
  */
 
-extern NSURLCacheStoragePolicy JAHPCacheStoragePolicyForRequestAndResponse(NSURLRequest * request, NSHTTPURLResponse * response);
+FOUNDATION_EXPORT NSURLCacheStoragePolicy JAHPCacheStoragePolicyForRequestAndResponse(NSURLRequest * request, NSHTTPURLResponse * response);

--- a/Source/JiveAuthenticatingHTTPProtocol/JAHPCacheStoragePolicy.m
+++ b/Source/JiveAuthenticatingHTTPProtocol/JAHPCacheStoragePolicy.m
@@ -47,7 +47,7 @@
 
 #import "JAHPCacheStoragePolicy.h"
 
-extern NSURLCacheStoragePolicy JAHPCacheStoragePolicyForRequestAndResponse(NSURLRequest * request, NSHTTPURLResponse * response)
+FOUNDATION_EXPORT NSURLCacheStoragePolicy JAHPCacheStoragePolicyForRequestAndResponse(NSURLRequest * request, NSHTTPURLResponse * response)
 // See comment in header.
 {
     BOOL                        cacheable;

--- a/Source/JiveAuthenticatingHTTPProtocol/JAHPCanonicalRequest.h
+++ b/Source/JiveAuthenticatingHTTPProtocol/JAHPCanonicalRequest.h
@@ -61,4 +61,4 @@
  *  \returns The canonical request; should never be nil.
  */
 
-extern NSMutableURLRequest * JAHPCanonicalRequestForRequest(NSURLRequest *request);
+FOUNDATION_EXPORT NSMutableURLRequest * JAHPCanonicalRequestForRequest(NSURLRequest *request);

--- a/Source/JiveAuthenticatingHTTPProtocol/JAHPCanonicalRequest.m
+++ b/Source/JiveAuthenticatingHTTPProtocol/JAHPCanonicalRequest.m
@@ -343,7 +343,7 @@ static void CanonicaliseHeaders(NSMutableURLRequest * request)
 
 #pragma mark * API
 
-extern NSMutableURLRequest * JAHPCanonicalRequestForRequest(NSURLRequest *request)
+FOUNDATION_EXPORT NSMutableURLRequest * JAHPCanonicalRequestForRequest(NSURLRequest *request)
 {
     NSMutableURLRequest *   result;
     NSString *              scheme;

--- a/Source/JiveAuthenticatingHTTPProtocol/JAHPQNSURLSessionDemux.m
+++ b/Source/JiveAuthenticatingHTTPProtocol/JAHPQNSURLSessionDemux.m
@@ -73,9 +73,9 @@
 
 - (instancetype)initWithTask:(NSURLSessionDataTask *)task delegate:(id<NSURLSessionDataDelegate>)delegate modes:(NSArray *)modes
 {
-    assert(task != nil);
-    assert(delegate != nil);
-    assert(modes != nil);
+    NSParameterAssert(task != nil);
+    NSParameterAssert(delegate != nil);
+    NSParameterAssert(modes != nil);
     
     self = [super init];
     if (self != nil) {
@@ -89,14 +89,14 @@
 
 - (void)performBlock:(dispatch_block_t)block
 {
-    assert(self.delegate != nil);
-    assert(self.thread != nil);
+    NSParameterAssert(self.delegate != nil);
+    NSParameterAssert(self.thread != nil);
     [self performSelector:@selector(performBlockOnClientThread:) onThread:self.thread withObject:[block copy] waitUntilDone:NO modes:self.modes];
 }
 
 - (void)performBlockOnClientThread:(dispatch_block_t)block
 {
-    assert([NSThread currentThread] == self.thread);
+    NSParameterAssert([NSThread currentThread] == self.thread);
     block();
 }
 
@@ -149,8 +149,8 @@
     NSURLSessionDataTask *          task;
     JAHPQNSURLSessionDemuxTaskInfo *    taskInfo;
     
-    assert(request != nil);
-    assert(delegate != nil);
+    NSParameterAssert(request != nil);
+    NSParameterAssert(delegate != nil);
     // modes may be nil
     
     if ([modes count] == 0) {
@@ -158,7 +158,7 @@
     }
     
     task = [self.session dataTaskWithRequest:request];
-    assert(task != nil);
+    NSParameterAssert(task != nil);
     
     taskInfo = [[JAHPQNSURLSessionDemuxTaskInfo alloc] initWithTask:task delegate:delegate modes:modes];
     
@@ -173,11 +173,11 @@
 {
     JAHPQNSURLSessionDemuxTaskInfo *    result;
     
-    assert(task != nil);
+    NSParameterAssert(task != nil);
     
     @synchronized (self) {
         result = self.taskInfoByTaskID[@(task.taskIdentifier)];
-        assert(result != nil);
+        NSParameterAssert(result != nil);
     }
     return result;
 }
@@ -187,7 +187,7 @@
     JAHPQNSURLSessionDemuxTaskInfo *    taskInfo;
     
     taskInfo = [self taskInfoForTask:task];
-    if ([taskInfo.delegate respondsToSelector:@selector(URLSession:task:willPerformHTTPRedirection:newRequest:completionHandler:)]) {
+    if ([taskInfo.delegate respondsToSelector:_cmd]) {
         [taskInfo performBlock:^{
             [taskInfo.delegate URLSession:session task:task willPerformHTTPRedirection:response newRequest:newRequest completionHandler:completionHandler];
         }];
@@ -201,7 +201,7 @@
     JAHPQNSURLSessionDemuxTaskInfo *    taskInfo;
     
     taskInfo = [self taskInfoForTask:task];
-    if ([taskInfo.delegate respondsToSelector:@selector(URLSession:task:didReceiveChallenge:completionHandler:)]) {
+    if ([taskInfo.delegate respondsToSelector:_cmd]) {
         [taskInfo performBlock:^{
             [taskInfo.delegate URLSession:session task:task didReceiveChallenge:challenge completionHandler:completionHandler];
         }];
@@ -215,7 +215,7 @@
     JAHPQNSURLSessionDemuxTaskInfo *    taskInfo;
     
     taskInfo = [self taskInfoForTask:task];
-    if ([taskInfo.delegate respondsToSelector:@selector(URLSession:task:needNewBodyStream:)]) {
+    if ([taskInfo.delegate respondsToSelector:_cmd]) {
         [taskInfo performBlock:^{
             [taskInfo.delegate URLSession:session task:task needNewBodyStream:completionHandler];
         }];
@@ -229,7 +229,7 @@
     JAHPQNSURLSessionDemuxTaskInfo *    taskInfo;
     
     taskInfo = [self taskInfoForTask:task];
-    if ([taskInfo.delegate respondsToSelector:@selector(URLSession:task:didSendBodyData:totalBytesSent:totalBytesExpectedToSend:)]) {
+    if ([taskInfo.delegate respondsToSelector:_cmd]) {
         [taskInfo performBlock:^{
             [taskInfo.delegate URLSession:session task:task didSendBodyData:bytesSent totalBytesSent:totalBytesSent totalBytesExpectedToSend:totalBytesExpectedToSend];
         }];
@@ -252,7 +252,7 @@
     // after calling the delegate, otherwise the client thread side of the -performBlock: code can
     // find itself with an invalidated task info.
     
-    if ([taskInfo.delegate respondsToSelector:@selector(URLSession:task:didCompleteWithError:)]) {
+    if ([taskInfo.delegate respondsToSelector:_cmd]) {
         [taskInfo performBlock:^{
             [taskInfo.delegate URLSession:session task:task didCompleteWithError:error];
             [taskInfo invalidate];
@@ -267,7 +267,7 @@
     JAHPQNSURLSessionDemuxTaskInfo *    taskInfo;
     
     taskInfo = [self taskInfoForTask:dataTask];
-    if ([taskInfo.delegate respondsToSelector:@selector(URLSession:dataTask:didReceiveResponse:completionHandler:)]) {
+    if ([taskInfo.delegate respondsToSelector:_cmd]) {
         [taskInfo performBlock:^{
             [taskInfo.delegate URLSession:session dataTask:dataTask didReceiveResponse:response completionHandler:completionHandler];
         }];
@@ -281,7 +281,7 @@
     JAHPQNSURLSessionDemuxTaskInfo *    taskInfo;
     
     taskInfo = [self taskInfoForTask:dataTask];
-    if ([taskInfo.delegate respondsToSelector:@selector(URLSession:dataTask:didBecomeDownloadTask:)]) {
+    if ([taskInfo.delegate respondsToSelector:_cmd]) {
         [taskInfo performBlock:^{
             [taskInfo.delegate URLSession:session dataTask:dataTask didBecomeDownloadTask:downloadTask];
         }];
@@ -293,7 +293,7 @@
     JAHPQNSURLSessionDemuxTaskInfo *    taskInfo;
     
     taskInfo = [self taskInfoForTask:dataTask];
-    if ([taskInfo.delegate respondsToSelector:@selector(URLSession:dataTask:didReceiveData:)]) {
+    if ([taskInfo.delegate respondsToSelector:_cmd]) {
         [taskInfo performBlock:^{
             [taskInfo.delegate URLSession:session dataTask:dataTask didReceiveData:data];
         }];
@@ -305,7 +305,7 @@
     JAHPQNSURLSessionDemuxTaskInfo *    taskInfo;
     
     taskInfo = [self taskInfoForTask:dataTask];
-    if ([taskInfo.delegate respondsToSelector:@selector(URLSession:dataTask:willCacheResponse:completionHandler:)]) {
+    if ([taskInfo.delegate respondsToSelector:_cmd]) {
         [taskInfo performBlock:^{
             [taskInfo.delegate URLSession:session dataTask:dataTask willCacheResponse:proposedResponse completionHandler:completionHandler];
         }];


### PR DESCRIPTION
Based on https://github.com/jivesoftware/JiveAuthenticatingHTTPProtocol/pull/10

Fixed an issue for the case when wrong credentials are entered by the user.
My memoization fix https://github.com/jivesoftware/JiveAuthenticatingHTTPProtocol/pull/9 has caused it.

The issue has been fixed for both the existing `UIWebView` based demo and for the `WKWebView` one.

### Issue description
The page would not end up loading since wrong credentials will constantly be provided to the authentication challenge callback. For this reason, the credentials alert would not show up (since the credentials have been memoized but they are wrong).

### The fix

1. Fixed the condition for supplying the memoized credentials

```obj-c
-(BOOL)isUserInputCredentialsMemoized {
    
    BOOL hasInput = (nil != self.userInput);
    BOOL result = hasInput && self.isUserInputAcceptedByServer;
    
    return result;
}
```

2. Marking credentials as "valid" in `webViewDidFinishLoad:`
If not marked, the alert will show up all over again until cancelled by the user (as it had before).